### PR TITLE
fix missing default offset

### DIFF
--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -60,6 +60,7 @@ export default class Carousel extends Component {
     })),
   };
   static defaultProps = {
+    offset: 0,
     slidesPerPage: 1,
     slidesPerScroll: 1,
     animationSpeed: 500,


### PR DESCRIPTION
This fixes #72. The issue was that `getProp('offset')` returned `undefined` if `offset` wasn't provided, and a number + `undefined` is `NaN`.

- [ ] `package.json:version` has been updated with `npm version patch` (or `major/minor` as appropriate)
- [ ] `@brainhubeu/react-carousel` version has been updated in `docs-www/package.json` to the same which is in `package.json:version`
