### PR TITLE
Added description for dots parameter in documentation

### DIFF
--- a/docs-www/package.json
+++ b/docs-www/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@brainhubeu/gatsby-docs-kit": "^1.0.1",
-    "@brainhubeu/react-carousel": "^1.10.6",
+    "@brainhubeu/react-carousel": "^1.10.7",
     "gatsby": "^1.9.270",
     "react-fa": "^5.0.0"
   },

--- a/docs/api/carousel.md
+++ b/docs/api/carousel.md
@@ -35,7 +35,9 @@
 * ```keepDirectionWhenDragging: Boolean``` While dragging, it doesn't matter which slide is the nearest one, but in what direction you dragged.
 
 * ```animationSpeed: Number``` Determines transition duration in milliseconds.
- 
+
+* ```dots: Boolean``` Renders default dots under the carousel.
+
 ## Default Properties:
 
 - ```slidesPerPage: 1```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainhubeu/react-carousel",
-  "version": "1.10.6",
+  "version": "1.10.7",
   "description": "Carousel component for React",
   "engines": {
     "npm": ">=4"


### PR DESCRIPTION
- [x] `package.json:version` has been updated with `npm version patch` (or `major/minor` as appropriate)
- [x] `@brainhubeu/react-carousel` version has been updated in `docs-www/package.json` to the same which is in `package.json:version`

This is a fix for #76 reported by @jaworek