### PR TITLE
Fix for infinite scroll

### DIFF
--- a/docs-www/package.json
+++ b/docs-www/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@brainhubeu/gatsby-docs-kit": "^1.0.1",
-    "@brainhubeu/react-carousel": "^1.10.11",
+    "@brainhubeu/react-carousel": "^1.10.12",
     "gatsby": "^1.9.270",
     "react-fa": "^5.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainhubeu/react-carousel",
-  "version": "1.10.11",
+  "version": "1.10.12",
   "description": "Carousel component for React",
   "engines": {
     "npm": ">=4"
@@ -105,7 +105,7 @@
     "responsive",
     "gallery",
     "rwd"
-   ],
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/brainhubeu/react-carousel"

--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -377,7 +377,7 @@ export default class Carousel extends Component {
   onTransitionEnd = () => {
     this.setState({
       transitionEnabled: false,
-      infiniteTransitionFrom: null,
+      infiniteTransitionFrom: this.getProp('infinite') ? this.getCurrentValue() : null,
     });
   };
 


### PR DESCRIPTION
This fixes #83. The issue was that `onTransitionEnd` function always updated state `infiniteTransitionFrom` to `null`, then `getNeededAdditionalClones` function calculated incorrectly number of necessary clones.

- [x] `package.json:version` has been updated with `npm version patch` (or `major/minor` as appropriate)
- [x] `@brainhubeu/react-carousel` version has been updated in `docs-www/package.json` to the same which is in `package.json:version`
