### PR TITLE
fix(dragging): Pooled events to reuse inside setState.

### DIFF
--- a/docs-www/package.json
+++ b/docs-www/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@brainhubeu/gatsby-docs-kit": "^1.0.3",
-    "@brainhubeu/react-carousel": "^1.10.24",
+    "@brainhubeu/react-carousel": "^1.10.25",
     "gatsby": "^1.9.279",
     "react-fa": "^5.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainhubeu/react-carousel",
-  "version": "1.10.24",
+  "version": "1.10.25",
   "description": "Carousel component for React",
   "engines": {
     "npm": ">=4"

--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -299,9 +299,10 @@ export default class Carousel extends Component {
   onMouseDown = (e, index) => {
     e.preventDefault();
     e.stopPropagation();
+    const { pageX } = e;
     this.setState(() => ({
       clicked: index,
-      dragStart: e.pageX,
+      dragStart: pageX,
     }));
   };
 
@@ -310,9 +311,10 @@ export default class Carousel extends Component {
    * @param {event} e event
    */
   onMouseMove = e => {
+    const { pageX } = e;
     if (this.state.dragStart !== null) {
       this.setState(previousState => ({
-        dragOffset: e.pageX - previousState.dragStart,
+        dragOffset: pageX - previousState.dragStart,
       }));
     }
   };
@@ -323,9 +325,10 @@ export default class Carousel extends Component {
    * @param {number} index of the element drag started on
    */
   onTouchStart = (e, index) => {
+    const { changedTouches } = e;
     this.setState(() => ({
       clicked: index,
-      dragStart: e.changedTouches[0].pageX,
+      dragStart: changedTouches[0].pageX,
     }));
   };
 
@@ -338,9 +341,10 @@ export default class Carousel extends Component {
       e.preventDefault();
       e.stopPropagation();
     }
+    const { changedTouches } = e;
     if (this.state.dragStart !== null) {
       this.setState(previousState => ({
-        dragOffset: e.changedTouches[0].pageX - previousState.dragStart,
+        dragOffset: changedTouches[0].pageX - previousState.dragStart,
       }));
     }
   };


### PR DESCRIPTION
In a previous refactor, the setState methods were changed to use the prevState prop, but this lost the event received on the function, so the needed properties were desesctructured from the original event so it can be used inside the setState.

Solves #147 

No breaking changes

- [x] `package.json:version` has been updated with `npm version patch` (or `major/minor` as appropriate)
- [x] `@brainhubeu/react-carousel` version has been updated in `docs-www/package.json` to the same which is in `package.json:version`
