### PR TITLE
attach listeners to parent element

### DIFF
--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -90,11 +90,11 @@ export default class Carousel extends Component {
 
     // adding event listeners for swipe
     if (this.node) {
-      this.node.ownerDocument.addEventListener('mousemove', this.onMouseMove, true);
-      this.node.ownerDocument.addEventListener('mouseup', this.onMouseUpTouchEnd, true);
-      this.node.ownerDocument.addEventListener('touchstart', this.simulateEvent, true);
-      this.node.ownerDocument.addEventListener('touchmove', this.simulateEvent, { passive: false });
-      this.node.ownerDocument.addEventListener('touchend', this.simulateEvent, true);
+      this.node.parentElement.addEventListener('mousemove', this.onMouseMove, true);
+      this.node.parentElement.addEventListener('mouseup', this.onMouseUpTouchEnd, true);
+      this.node.parentElement.addEventListener('touchstart', this.simulateEvent, true);
+      this.node.parentElement.addEventListener('touchmove', this.simulateEvent, { passive: false });
+      this.node.parentElement.addEventListener('touchend', this.simulateEvent, true);
     }
 
     // setting size of a carousel in state
@@ -133,11 +133,11 @@ export default class Carousel extends Component {
     this.trackRef && this.trackRef.removeEventListener('transitionend', this.onTransitionEnd);
 
     if (this.node) {
-      this.node.ownerDocument.removeEventListener('mousemove', this.onMouseMove);
-      this.node.ownerDocument.removeEventListener('mouseup', this.onMouseUp);
-      this.node.ownerDocument.removeEventListener('touchstart', this.simulateEvent);
-      this.node.ownerDocument.removeEventListener('touchmove', this.simulateEvent);
-      this.node.ownerDocument.removeEventListener('touchend', this.simulateEvent);
+      this.node.parentElement.removeEventListener('mousemove', this.onMouseMove);
+      this.node.parentElement.removeEventListener('mouseup', this.onMouseUp);
+      this.node.parentElement.removeEventListener('touchstart', this.simulateEvent);
+      this.node.parentElement.removeEventListener('touchmove', this.simulateEvent);
+      this.node.parentElement.removeEventListener('touchend', this.simulateEvent);
     }
 
     window.removeEventListener('resize', this.onResize);


### PR DESCRIPTION

- [ ] `package.json:version` has been updated with `npm version patch` (or `major/minor` as appropriate)
- [ ] `@brainhubeu/react-carousel` version has been updated in `docs-www/package.json` to the same which is in `package.json:version`

Attach listeners for simulated events to the carousel wrapper instead of window document