### PR TITLE
Remove warnings of memory leak and 'read property offsetWidth of null…

### DIFF
--- a/docs-www/package.json
+++ b/docs-www/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@brainhubeu/gatsby-docs-kit": "^1.0.3",
-    "@brainhubeu/react-carousel": "^1.10.26",
+    "@brainhubeu/react-carousel": "^1.10.28",
     "gatsby": "^1.9.279",
     "react-fa": "^5.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainhubeu/react-carousel",
-  "version": "1.10.27",
+  "version": "1.10.28",
   "description": "Carousel component for React",
   "engines": {
     "npm": ">=4"

--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -283,12 +283,14 @@ export default class Carousel extends Component {
    onResize = throttle(() => {
      const arrowLeftWidth = this.arrowLeftNode && this.arrowLeftNode.offsetWidth;
      const arrowRightWidth = this.arrowRightNode && this.arrowRightNode.offsetWidth;
-     const width = this.node.offsetWidth - (arrowLeftWidth || 0) - (arrowRightWidth || 0);
+     const width = this.node && this.node.offsetWidth - (arrowLeftWidth || 0) - (arrowRightWidth || 0);
 
-     this.setState(() => ({
-       carouselWidth: width,
-       windowWidth: window.innerWidth,
-     }));
+     if (this.node) {
+       this.setState(() => ({
+         carouselWidth: width,
+         windowWidth: window.innerWidth,
+       }));
+     }
    }, config.resizeEventListenerThrottle);
 
   /**

--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -281,16 +281,18 @@ export default class Carousel extends Component {
    * @type {Function}
    */
    onResize = throttle(() => {
+     if (!this.node) {
+       return;
+     }
+
      const arrowLeftWidth = this.arrowLeftNode && this.arrowLeftNode.offsetWidth;
      const arrowRightWidth = this.arrowRightNode && this.arrowRightNode.offsetWidth;
-     const width = this.node && this.node.offsetWidth - (arrowLeftWidth || 0) - (arrowRightWidth || 0);
+     const width = this.node.offsetWidth - (arrowLeftWidth || 0) - (arrowRightWidth || 0);
 
-     if (this.node) {
-       this.setState(() => ({
-         carouselWidth: width,
-         windowWidth: window.innerWidth,
-       }));
-     }
+     this.setState(() => ({
+       carouselWidth: width,
+       windowWidth: window.innerWidth,
+     }));
    }, config.resizeEventListenerThrottle);
 
   /**


### PR DESCRIPTION
…' message



- [x] `package.json:version` has been updated with `npm version patch` (or `major/minor` as appropriate)
- [x] `@brainhubeu/react-carousel` version has been updated in `docs-www/package.json` to the same which is in `package.json:version`
