### PR TITLE
Fix cleanup of mouseup event listener

### DIFF
--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -134,7 +134,7 @@ export default class Carousel extends Component {
 
     if (this.node) {
       this.node.parentElement.removeEventListener('mousemove', this.onMouseMove);
-      this.node.parentElement.removeEventListener('mouseup', this.onMouseUp);
+      this.node.parentElement.removeEventListener('mouseup', this.onMouseUpTouchEnd);
       this.node.parentElement.removeEventListener('touchstart', this.simulateEvent);
       this.node.parentElement.removeEventListener('touchmove', this.simulateEvent);
       this.node.parentElement.removeEventListener('touchend', this.simulateEvent);


### PR DESCRIPTION
I noticed that the `mouseup` event listener was not correctly being cleaned up. 
Looks like it was missed when the handler was renamed from `onMouseUp` to `onMouseUpTouchEnd`.

I do wonder whether possibly related to #114, but was unable to replicate original issue. 
