### PR TITLE
create robots.txt when deploying GH pages for a PR

### DIFF
--- a/tools/deploy-gh-pages-pr.sh
+++ b/tools/deploy-gh-pages-pr.sh
@@ -64,6 +64,10 @@ yarn install --non-interactive
 cd docs-www
 yarn install --non-interactive
 PATH_PREFIX=gh-pages-rc-$page_number yarn build
+cat <<EOF >> public/robots.txt
+User-agent: *
+Disallow: /
+EOF
 cd ..
 
 mkdir -p gh-pages-branch


### PR DESCRIPTION
Deployed to https://beghp.github.io/gh-pages-rc-6<br><br>- [ ] `package.json:version` has been updated with `npm version patch` (or `major/minor` as appropriate)<br>- [ ] `@brainhubeu/react-carousel` version has been updated in `docs-www/package.json` to the same which is in `package.json:version`<br><br>