### PR TITLE
add importing css to gettingStarted docs

### DIFF
--- a/docs/gettingStarted.md
+++ b/docs/gettingStarted.md
@@ -10,6 +10,7 @@ $ npm i @brainhubeu/react-carousel
 And then you can import Carousel and Dots components:
 ```
 import Carousel, { Dots } from '@brainhubeu/react-carousel';
+import '@brainhubeu/react-carousel/lib/style.css';
 ```
 
 You can find usage examples [here](/docs/examples/simpleUsage/)


### PR DESCRIPTION
It resolves https://github.com/brainhubeu/react-carousel/issues/266

- [ ] `package.json:version` has been updated with `npm version patch` (or `major/minor` as appropriate)
- [ ] `@brainhubeu/react-carousel` version has been updated in `docs-www/package.json` to the same which is in `package.json:version`
