### PR TITLE
[251] use window.outerWidth & window.outerHeight to fix an issue on chrome 80+

### DIFF
--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -291,7 +291,7 @@ class Carousel extends Component {
 
     this.setState(() => ({
       carouselWidth: width,
-      windowWidth: window.innerWidth,
+      windowWidth: window.outerWidth,
     }));
   }, config.resizeEventListenerThrottle);
 

--- a/test/unit/carousel.test.js
+++ b/test/unit/carousel.test.js
@@ -18,8 +18,8 @@ const resizeEvent = document.createEvent('Event');
 resizeEvent.initEvent('resize', true, true);
 
 window.resizeTo = (width, height) => {
-  window.innerWidth = width || global.window.innerWidth;
-  window.innerHeight = height || global.window.innerHeight;
+  window.outerWidth = width || global.window.outerWidth;
+  window.outerHeight = height || global.window.outerHeight;
   window.dispatchEvent(resizeEvent);
 };
 


### PR DESCRIPTION
Deployed to https://beghp.github.io/gh-pages-rc-2<br>It resolves https://github.com/brainhubeu/react-carousel/issues/251<br><br><br>- [ ] `package.json:version` has been updated with `npm version patch` (or `major/minor` as appropriate)<br>- [ ] `@brainhubeu/react-carousel` version has been updated in `docs-www/package.json` to the same which is in `package.json:version`<br><br>