### PR TITLE
[265] Add transition duration to mouseUp event

### DIFF
--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -375,6 +375,7 @@ class Carousel extends Component {
         clicked: null,
         dragOffset: 0,
         dragStart: null,
+        transitionEnabled: true,
       }));
     }
   };


### PR DESCRIPTION
Deployed to https://beghp.github.io/gh-pages-rc-5<br>The problem was the mouseUp event. We didn't add transition duration when the user releasing a slide.<br><br>- [ ] `package.json:version` has been updated with `npm version patch` (or `major/minor` as appropriate)<br>- [ ] `@brainhubeu/react-carousel` version has been updated in `docs-www/package.json` to the same which is in `package.json:version`<br><br>