### PR TITLE
Added BrainhubCarouselItem--visible className 

### DIFF
--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -534,6 +534,8 @@ class Carousel extends Component {
     const children = this.getChildren();
     const numberOfClonesLeft = this.getClonesLeft();
     const numberOfClonesRight = this.getClonesRight();
+    const slidesPerPage = this.getProp('slidesPerPage');
+    const centered = this.getProp('centered');
 
     const trackLengthMultiplier = 1 + (this.getProp('infinite') ? numberOfClonesLeft + numberOfClonesRight : 0);
     const trackWidth = this.state.carouselWidth * children.length * trackLengthMultiplier;
@@ -595,6 +597,8 @@ class Carousel extends Component {
                 onTouchStart={this.onTouchStart}
                 clickable={this.getProp('clickToChange')}
                 isDragging={Math.abs(this.state.dragOffset) > this.props.minDraggableOffset}
+                slidesPerPage={slidesPerPage}
+                carouselIsCentered={centered}
               >
                 {carouselItem}
               </CarouselItem>

--- a/src/components/CarouselItem.js
+++ b/src/components/CarouselItem.js
@@ -14,6 +14,8 @@ class CarouselItem extends PureComponent {
     index: PropTypes.number,
     currentSlideIndex: PropTypes.number,
     isDragging: PropTypes.bool,
+    slidesPerPage: PropTypes.number,
+    carouselIsCentered: PropTypes.bool,
   };
 
   onMouseDown = event => {
@@ -24,6 +26,21 @@ class CarouselItem extends PureComponent {
     this.props.onTouchStart(event, this.props.index);
   };
 
+  getIsVisible() {
+    if (this.props.carouselIsCentered) {
+      const itemsConsidered = this.props.slidesPerPage % 2 === 0
+        ? this.props.slidesPerPage - 1 : this.props.slidesPerPage;
+
+      const itemsRange = itemsConsidered / 2;
+
+      return this.props.index >= this.props.currentSlideIndex - itemsRange
+        && this.props.index <= this.props.currentSlideIndex + itemsRange;
+    } else {
+      return this.props.index >= this.props.currentSlideIndex
+          && this.props.index < Math.floor(this.props.currentSlideIndex + this.props.slidesPerPage);
+    }
+  }
+
   render() {
     return (
       <li
@@ -32,6 +49,7 @@ class CarouselItem extends PureComponent {
           {
             'BrainhubCarouselItem--clickable': this.props.clickable,
             'BrainhubCarouselItem--active': this.props.index === this.props.currentSlideIndex,
+            'BrainhubCarouselItem--visible': this.getIsVisible(),
           },
         )}
         style={{


### PR DESCRIPTION
It will be applied to every slide currently fully visible on screen

Fixes: https://github.com/brainhubeu/react-carousel/issues/313

**Idea for centered carousel**:
- active item is in the middle
- when there is even number of items shown, on right/left there always is one that is cut in half
- when there is uneven number of items shown, this situation does not happen.

That's why i'm subtracting one from elements count when there is even number of items per page, and why I don't when there is uneven count.

**Idea for not centered carousel**:
- active element is always the one on the left, making calculations easier.

**Possible problems/ways to improve**:
- I don't have any idea how to support `offset` prop, neither am I sure if it should be handled.

- [ ] `package.json:version` has been updated with `npm version patch` (or `major/minor` as appropriate)
- [ ] `@brainhubeu/react-carousel` version has been updated in `docs-www/package.json` to the same which is in `package.json:version`
