### PR TITLE
gatsby group in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,14 @@
       "managers": [
         "circleci"
       ]
+    },
+    {
+      "groupName": "gatsby",
+      "managerBranchPrefix": "gatsby",
+      "packagePatterns": [
+        "gatsby"
+      ],
+      "rangeStrategy": "pin"
     }
   ]
 }


### PR DESCRIPTION

- [ ] `package.json:version` has been updated with `npm version patch` (or `major/minor` as appropriate)
- [ ] `@brainhubeu/react-carousel` version has been updated in `docs-www/package.json` to the same which is in `package.json:version`
