### PR TITLE
Docs responsive fix

### DIFF
--- a/docs/examples/responsive.md
+++ b/docs/examples/responsive.md
@@ -1,5 +1,6 @@
 ## Responsive
 You can set all props (except value, onChange, responsive, children) to different values on different screen resolutions. The props set will override the existing prop (if already set).
+
 ```jsx render
 <Carousel
   slidesPerPage={3}

--- a/docs/examples/responsive.md
+++ b/docs/examples/responsive.md
@@ -1,8 +1,19 @@
 ## Responsive
-You can set all props (except value, onChange, responsive, children) to different values on different screen resolutions.
+You can set all props (except value, onChange, responsive, children) to different values on different screen resolutions. The props set will override the existing prop (if already set).
 ```jsx render
 <Carousel
   slidesPerPage={3}
+  arrows
+  breakpoints={{
+    640: {
+      slidesPerPage={1},
+      arrows: false
+    },
+    768: {
+      slidesPerPage={2},
+      arrows: false
+    }
+  }}
 >
   <img src={imageOne} />
   <img src={imageTwo} />


### PR DESCRIPTION
See #355 

- [ ] `package.json:version` has been updated with `npm version patch` (or `major/minor` as appropriate)
- [ ] `@brainhubeu/react-carousel` version has been updated in `docs-www/package.json` to the same which is in `package.json:version`
