### PR TITLE
Dagoss docs responsive fix

### DIFF
--- a/docs/examples/responsive.md
+++ b/docs/examples/responsive.md
@@ -7,11 +7,11 @@ You can set all props (except value, onChange, responsive, children) to differen
   arrows
   breakpoints={{
     640: {
-      slidesPerPage={1},
+      slidesPerPage: 1,
       arrows: false
     },
     768: {
-      slidesPerPage={2},
+      slidesPerPage: 2,
       arrows: false
     }
   }}

--- a/docs/examples/responsive.md
+++ b/docs/examples/responsive.md
@@ -10,7 +10,7 @@ You can set all props (except value, onChange, responsive, children) to differen
       slidesPerPage: 1,
       arrows: false
     },
-    768: {
+    900: {
       slidesPerPage: 2,
       arrows: false
     }


### PR DESCRIPTION
Deployed to https://beghp.github.io/gh-pages-rc-9<br><br>- [ ] `package.json:version` has been updated with `npm version patch` (or `major/minor` as appropriate)<br>- [ ] `@brainhubeu/react-carousel` version has been updated in `docs-www/package.json` to the same which is in `package.json:version`<br><br>