### PR TITLE
Fix issue that caused carousel to break in Preact

### DIFF
--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -110,22 +110,16 @@ class Carousel extends Component {
     this.resetInterval();
   }
 
-  shouldComponentUpdate(newProps) {
-    const valueChanged = this.checkIfValueChanged(newProps);
+  componentDidUpdate(prevProps) {
+    const valueChanged = this.checkIfValueChanged(prevProps);
+    if (this.getProp('autoPlay') !== this.getProp('autoPlay', prevProps) || valueChanged) {
+      this.resetInterval();
+    }
 
     if (valueChanged) {
       this.setState({
         transitionEnabled: true,
       });
-      return false;
-    }
-    return true;
-  }
-
-  componentDidUpdate(prevProps) {
-    const valueChanged = this.checkIfValueChanged(prevProps);
-    if (this.getProp('autoPlay') !== this.getProp('autoPlay', prevProps) || valueChanged) {
-      this.resetInterval();
     }
   }
 
@@ -384,9 +378,10 @@ class Carousel extends Component {
    * Handler setting transitionEnabled value in state to false after transition animation ends
    */
   onTransitionEnd = () => {
+    const infinite = this.getProps('infinite');
     this.setState(() => ({
-      transitionEnabled: false,
-      infiniteTransitionFrom: this.getProp('infinite') ? this.getCurrentValue() : null,
+      transitionEnabled: !infinite,
+      infiniteTransitionFrom: infinite ? this.getCurrentValue() : null,
     }));
   };
 


### PR DESCRIPTION
When using this library with Preact the carousel won't transition. Calling `setState` before returning false inside `shouldComponentUpdate` does not appear to cause a re-render in that library.

I moved that code into a `componentDidUpdate` which I can see was done in the past but caused issues with animating the last slide and infinite transitions. This is solved by checking if infinite is true in `onTransitionEnd`.

- Appears to work correctly in Preact now.
- The last slide still transitions properly.
- Infinite carousels still transition properly.
- Test pass

Let me know if there are any other regressions I should test.

- [ ] `package.json:version` has been updated with `npm version patch` (or `major/minor` as appropriate)
- [ ] `@brainhubeu/react-carousel` version has been updated in `docs-www/package.json` to the same which is in `package.json:version`
