### PR TITLE
fix: only add drag event listeners when dragging is enabled

### DIFF
--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -590,6 +590,7 @@ class Carousel extends Component {
                 onTouchStart={this.onTouchStart}
                 clickable={this.getProp('clickToChange')}
                 isDragging={Math.abs(this.state.dragOffset) > this.props.minDraggableOffset}
+                isDraggingEnabled={this.props.draggable}
               >
                 {carouselItem}
               </CarouselItem>

--- a/src/components/CarouselItem.js
+++ b/src/components/CarouselItem.js
@@ -14,6 +14,7 @@ class CarouselItem extends PureComponent {
     index: PropTypes.number,
     currentSlideIndex: PropTypes.number,
     isDragging: PropTypes.bool,
+    isDraggingEnabled: PropTypes.bool,
   };
 
   onMouseDown = event => {
@@ -42,8 +43,8 @@ class CarouselItem extends PureComponent {
           minWidth: `${this.props.width}px`,
           pointerEvents: this.props.isDragging ? 'none' : null,
         }}
-        onMouseDown={this.onMouseDown}
-        onTouchStart={this.onTouchStart}
+        onMouseDown={this.props.isDraggingEnabled && this.onMouseDown}
+        onTouchStart={this.props.isDraggingEnabled && this.onTouchStart}
       >
         {this.props.children}
       </li>


### PR DESCRIPTION
Resolves issue #364 

- [ ] `package.json:version` has been updated with `npm version patch` (or `major/minor` as appropriate)
- [ ] `@brainhubeu/react-carousel` version has been updated in `docs-www/package.json` to the same which is in `package.json:version`
