### PR TITLE
fix className retrieval

### DIFF
--- a/src/components/CarouselDots.js
+++ b/src/components/CarouselDots.js
@@ -68,8 +68,9 @@ class CarouselDots extends Component {
   }
 
   render() {
+    const { className = '', rtl } = this.props;
     return (
-      <ul className={classnames('BrainhubCarousel__dots', this.getProp('className'), this.props.rtl ? 'BrainhubCarousel__dots--isRTL' : '')}>
+      <ul className={classnames('BrainhubCarousel__dots', className, rtl ? 'BrainhubCarousel__dots--isRTL' : '')}>
         {this.renderCarouselDots()}
       </ul>
     );


### PR DESCRIPTION

- [ ] `package.json:version` has been updated with `npm version patch` (or `major/minor` as appropriate)
- [ ] `@brainhubeu/react-carousel` version has been updated in `docs-www/package.json` to the same which is in `package.json:version`
