### PR TITLE
docs-www/reduxcache* in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ package-lock.json
 html-report/
 lib/
 test/cypress/videos/
+docs-www/reduxcache*


### PR DESCRIPTION

- [ ] `package.json:version` has been updated with `npm version patch` (or `major/minor` as appropriate)
- [ ] `@brainhubeu/react-carousel` version has been updated in `docs-www/package.json` to the same which is in `package.json:version`
