### PR TITLE
fix: pass null instead of boolean to drag event listener if disa…

### DIFF
--- a/src/components/CarouselItem.js
+++ b/src/components/CarouselItem.js
@@ -43,8 +43,8 @@ class CarouselItem extends PureComponent {
           minWidth: `${this.props.width}px`,
           pointerEvents: this.props.isDragging ? 'none' : null,
         }}
-        onMouseDown={this.props.isDraggingEnabled && this.onMouseDown}
-        onTouchStart={this.props.isDraggingEnabled && this.onTouchStart}
+        onMouseDown={this.props.isDraggingEnabled ? this.onMouseDown : null}
+        onTouchStart={this.props.isDraggingEnabled ? this.onTouchStart : null}
       >
         {this.props.children}
       </li>


### PR DESCRIPTION
React displays warnings when a boolean is passed to the eventListener. This should use a tertiary so that undefined is passed in if dragging is disabled.

```
Warning: Expected `onTouchStart` listener to be a function, instead got `false`.
If you used to conditionally omit it with onTouchStart={condition && value}, pass onTouchStart={condition ? value : undefined} instead.
```