### PR TITLE
ci skip when updating itself in docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ jobs:
             cd docs-www
             yarn add @brainhubeu/react-carousel --non-interactive
             git add .
-            git commit -m 'update @brainhubeu/react-carousel in docs-www'
+            git commit -m 'update @brainhubeu/react-carousel in docs-www [ci skip]'
       - run: git push origin $CIRCLE_BRANCH
       - run:
           name: publish gh pages


### PR DESCRIPTION

- [ ] `package.json:version` has been updated with `npm version patch` (or `major/minor` as appropriate)
- [ ] `@brainhubeu/react-carousel` version has been updated in `docs-www/package.json` to the same which is in `package.json:version`
