### PR TITLE
Fix/chawomack use tertiary

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainhubeu/react-carousel",
-  "version": "1.13.25",
+  "version": "1.13.26",
   "description": "Carousel component for React",
   "engines": {
     "npm": ">=6.14.4"


### PR DESCRIPTION
Deployed to https://beghp.github.io/gh-pages-rc-12<br><br>- [ ] `package.json:version` has been updated with `npm version patch` (or `major/minor` as appropriate)<br>- [ ] `@brainhubeu/react-carousel` version has been updated in `docs-www/package.json` to the same which is in `package.json:version`<br><br>