### PR TITLE
Fixes issue #181

### DIFF
--- a/docs/examples/clickToChange.md
+++ b/docs/examples/clickToChange.md
@@ -11,3 +11,8 @@ By default, clicking the slides does nothing. You can change that behavior with 
  <img src={imageThree} />
 </Carousel>
 ```
+
+### Apple iOS
+The carousel items should not be associated with the CSS
+property `justify-content: center;`. This property causes
+wrong justification on iOS.

--- a/src/styles/CarouselItem.scss
+++ b/src/styles/CarouselItem.scss
@@ -1,6 +1,5 @@
 .BrainhubCarouselItem {
   display: flex;
-  justify-content: center;
   align-items: center;
   position: relative;
   &.BrainhubCarouselItem--clickable {


### PR DESCRIPTION
The reason, that the most right photo occupies all the carousel was the CSS property `justifiy-content: center`. When removing this property, the last image doesn't occupy all the carousel and it's possible to select all images. 
Due to small carousel width, there is still some overlap between the images. In my test this could be avoided, when one slide per page was chosen.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#181: click to change - unable to select a photo for a low width of the screen](https://issuehunt.io/repos/116013398/issues/181)
---
</details>
<!-- /Issuehunt content-->