### PR TITLE
Fixes #181

### DIFF
--- a/docs/examples/clickToChange.md
+++ b/docs/examples/clickToChange.md
@@ -11,8 +11,3 @@ By default, clicking the slides does nothing. You can change that behavior with 
  <img src={imageThree} />
 </Carousel>
 ```
-
-### Apple iOS
-The carousel items should not be associated with the CSS
-property `justify-content: center;`. This property causes
-wrong justification on iOS.

--- a/src/components/CarouselItem.js
+++ b/src/components/CarouselItem.js
@@ -17,6 +17,26 @@ class CarouselItem extends PureComponent {
     isDraggingEnabled: PropTypes.bool,
   };
 
+  constructor(props) {
+    super(props);
+    this.childrenRef = React.createRef();
+  }
+
+  /* ========== Resize, if necessary. Workaround for iOS safari ========== */
+  componentDidUpdate() {
+    this.childrenRef.current.style = null;
+    if (this.childrenRef.current.offsetWidth > this.props.width) {
+      this.childrenRef.current.style.width = `${this.props.width}px`;
+    }
+  }
+
+  getChildren() {
+    return React.cloneElement(
+      this.props.children,
+      { ref: this.childrenRef },
+    );
+  }
+
   onMouseDown = event => {
     this.props.onMouseDown(event, this.props.index);
   };
@@ -46,7 +66,7 @@ class CarouselItem extends PureComponent {
         onMouseDown={this.props.isDraggingEnabled ? this.onMouseDown : null}
         onTouchStart={this.props.isDraggingEnabled ? this.onTouchStart : null}
       >
-        {this.props.children}
+        {this.getChildren()}
       </li>
     );
   }

--- a/src/styles/CarouselItem.scss
+++ b/src/styles/CarouselItem.scss
@@ -1,5 +1,6 @@
 .BrainhubCarouselItem {
   display: flex;
+  justify-content: center;
   align-items: center;
   position: relative;
   &.BrainhubCarouselItem--clickable {


### PR DESCRIPTION
Now the images are scaled correctly on iOS. Setting the image-width, when the original image is bigger than the carousel item, does the trick.

- [X] an issue linked to the PR


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#181: click to change - unable to select a photo for a low width of the screen](https://issuehunt.io/repos/116013398/issues/181)
---
</details>
<!-- /Issuehunt content-->