### PR TITLE
Fix: animation when loading initial carousel

### DIFF
--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -116,7 +116,7 @@ class Carousel extends Component {
       this.resetInterval();
     }
 
-    if (valueChanged) {
+    if (!this.state.transitionEnabled) {
       this.setState({
         transitionEnabled: true,
       });


### PR DESCRIPTION
Fix according to PR #461. Now the animation is shown, when right arrow is pressed on the first picture.