### PR TITLE
Fixed blinking for iOS 12

### DIFF
--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -491,6 +491,7 @@ class Carousel extends Component {
     return dragOffset - currentValue * elementWidthWithOffset + additionalOffset - additionalClonesOffset;
   };
 
+  getIdCarouselItem = index => index % this.getChildren().length + 1;
 
   /* ========== rendering ========== */
   renderCarouselItems = () => {
@@ -552,6 +553,7 @@ class Carousel extends Component {
             [null, undefined].includes(carouselItem) ? null : (
               <CarouselItem
                 key={index}
+                id={this.getIdCarouselItem(index)}
                 currentSlideIndex={this.getActiveSlideIndex()}
                 index={index}
                 width={this.getCarouselElementWidth()}


### PR DESCRIPTION
I fixed the issue (blinking on iOS 12). The last width of every carousel item is stored in a map and this map is used, when new elements attached to the right side are mounted.

