### PR TITLE
fix: Adding 'rtl' to breakpoints prop-type shape

### DIFF
--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -59,6 +59,7 @@ class Carousel extends Component {
       animationSpeed: PropTypes.number,
       dots: PropTypes.bool,
       className: PropTypes.string,
+      rtl: PropTypes.bool,
     })),
   };
   static defaultProps = {


### PR DESCRIPTION
`const isRTL = this.getProp('rtl');` is called in `Carousel.render()` however the property is missing from the breakpoints `PropTypes.shape`.
