### PR TITLE
PR #461: Fixed blinking on iOS 12

### DIFF
--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -151,12 +151,8 @@ class Carousel extends Component {
     const additionalClones = this.getNeededAdditionalClones();
     return additionalClones < 0 ? -additionalClones : 0;
   };
-  getAdditionalClonesRight = () => {
-    const additionalClones = this.getNeededAdditionalClones();
-    return additionalClones > 0 ? additionalClones : 0;
-  };
   getClonesLeft = () => config.numberOfInfiniteClones + this.getAdditionalClonesLeft();
-  getClonesRight = () => config.numberOfInfiniteClones + this.getAdditionalClonesRight();
+  getClonesRight = () => config.numberOfInfiniteClones;
 
   getAdditionalClonesOffset = () =>
     -this.getChildren().length * this.getCarouselElementWidth() * this.getAdditionalClonesLeft();

--- a/src/components/CarouselItem.js
+++ b/src/components/CarouselItem.js
@@ -4,8 +4,6 @@ import classname from 'classnames';
 import '../styles/CarouselItem.scss';
 import ResizeObserver from 'resize-observer-polyfill';
 
-const childrenWidthMap = new Map();
-
 class CarouselItem extends PureComponent {
   static propTypes = {
     onMouseDown: PropTypes.func,
@@ -37,15 +35,7 @@ class CarouselItem extends PureComponent {
     }
   }
 
-  componentDidUnmount() {
-    childrenWidthMap.delete(this.props.id);
-  }
-
   observeWidth() {
-    if (childrenWidthMap.has(this.props.id)) {
-      this.childrenRef.current.style.width = childrenWidthMap.get(this.props.id);
-    }
-
     const resizeObserver = new ResizeObserver(() => {
       this.resizeChildren();
       resizeObserver.unobserve(this.childrenRef.current);
@@ -58,7 +48,6 @@ class CarouselItem extends PureComponent {
     if (this.childrenRef.current.offsetWidth > this.props.width) {
       this.childrenRef.current.style.width = `${this.props.width}px`;
     }
-    childrenWidthMap.set(this.props.id, this.childrenRef.current.offsetWidth);
   }
 
   getChildren() {


### PR DESCRIPTION
Blinking on iOS 12 can be fixed with this approach. Now the necessary clones on the right side don't change anymore.

