### PR TITLE
389 Lazy load slides feature

### DIFF
--- a/docs-www/gatsby-docs-kit.yml
+++ b/docs-www/gatsby-docs-kit.yml
@@ -48,6 +48,8 @@
           file: thumbnails.md
         - title: Flex Container
           file: flexContainer.md
+        - title: Lazy load
+          file: lazyload.md
     - title: Api
       dir: api
       items:

--- a/docs/examples/lazyload.md
+++ b/docs/examples/lazyload.md
@@ -1,0 +1,54 @@
+## Lazy load slides
+Loads only the nearest next/prev slides to the current one based on the value of the slidesPerPage variable. Check network tab, to see that images are preloaded on demand.
+```jsx render
+class MyCarousel extends React.Component {
+  constructor() {
+    super()
+    this.state = { value: 0 };
+    this.onChange = this.onChange.bind(this);
+  }
+
+  onChange(value) {
+    this.setState({ value });
+  }
+
+  render() {
+    return (
+    <div>
+      <input
+        type="number"
+        value={this.state.value}
+        onChange={e => this.onChange(parseInt(e.target.value || 0))}
+      />
+      <Carousel
+        value={this.state.value}
+        onChange={this.onChange}
+        arrows
+        slidesPerScroll={2}
+        slidesPerPage={2}
+        infinite
+        breakpoints={{
+          415: {
+            slidesPerScroll: 1,
+            slidesPerPage: 1,
+          },
+        }}
+        slides={[
+          (<img src={imageOne} />),
+          (<img src={imageTwo} />),
+          (<img src={imageThree} />),
+          (<img src={'https://randomwordgenerator.com/img/picture-generator/53e2d245424faa0df7c5d57bc32f3e7b1d3ac3e45659764e742a7cdd95_640.jpg'} />),
+          (<img src={'https://randomwordgenerator.com/img/picture-generator/54e3d04b4951af14f1dc8460962e33791c3ad6e04e50744172287ad29448c7_640.jpg'} />),
+          (<img src={'https://randomwordgenerator.com/img/picture-generator/52e6d6454c5bac14f1dc8460962e33791c3ad6e04e5074417c2d78dc974ec4_640.jpg'} />),
+          (<img src={'https://randomwordgenerator.com/img/picture-generator/53e0d74b4250ad14f1dc8460962e33791c3ad6e04e50744172277fd09549cd_640.jpg'} />),
+          (<img src={'https://randomwordgenerator.com/img/picture-generator/54e1d3434a57a514f1dc8460962e33791c3ad6e04e50744172277ed79044cd_640.jpg'} />),
+          (<img src={'https://randomwordgenerator.com/img/picture-generator/53e2d6414255af14f1dc8460962e33791c3ad6e04e50744075277cd39e48c3_640.jpg'} />),
+          (<img src={'https://randomwordgenerator.com/img/picture-generator/55e3d14a4f5aa414f1dc8460962e33791c3ad6e04e50744172287cd09f4cc4_640.jpg'} />),
+          (<img src={'https://randomwordgenerator.com/img/picture-generator/57e8d1404856ad14f1dc8460962e33791c3ad6e04e50744172297cdc924cc3_640.jpg'} />),
+        ]}
+      />
+    </div>
+    );
+  }
+}
+```

--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -36,6 +36,8 @@ class Carousel extends Component {
     centered: PropTypes.bool,
     infinite: PropTypes.bool,
     rtl: PropTypes.bool,
+    lazyLoad: PropTypes.bool,
+    lazyLoader: PropTypes.node,
     draggable: PropTypes.bool,
     keepDirectionWhenDragging: PropTypes.bool,
     animationSpeed: PropTypes.number,
@@ -61,6 +63,8 @@ class Carousel extends Component {
       dots: PropTypes.bool,
       className: PropTypes.string,
       rtl: PropTypes.bool,
+      lazyLoad: PropTypes.bool,
+      lazyLoader: PropTypes.node,
     })),
   };
   static defaultProps = {
@@ -70,6 +74,7 @@ class Carousel extends Component {
     animationSpeed: 500,
     draggable: true,
     rtl: false,
+    lazyLoad: true,
     minDraggableOffset: 10,
   };
 
@@ -84,6 +89,7 @@ class Carousel extends Component {
       transitionEnabled: false,
       infiniteTransitionFrom: props.infinite ? props.value : null, // indicates what slide we are transitioning from (in case of infinite carousel), contains number value or null
       isAutoPlayStopped: false,
+      lazyLoadedSlides: [],
     };
     this.interval = null;
   }
@@ -102,7 +108,10 @@ class Carousel extends Component {
       this.node.parentElement.addEventListener('touchend', this.simulateEvent, true);
     }
 
-    this.onResize();
+    this.onResize(() => {
+      this.setLazyLoadedSlides();
+    });
+
     // setting autoplay interval
     this.resetInterval();
   }
@@ -117,6 +126,10 @@ class Carousel extends Component {
       this.setState({
         transitionEnabled: true,
       });
+    }
+
+    if (valueChanged && this.props.lazyLoad) {
+      this.setLazyLoadedSlides();
     }
   }
 
@@ -183,6 +196,75 @@ class Carousel extends Component {
       }
     }
     return props[propName];
+  };
+
+  /**
+   * Function that stores indexes in the state of unique slides that should be lazy loaded.
+   */
+  setLazyLoadedSlides() {
+    const children = this.getChildren();
+    const currentSlideIndex = this.getCurrentSlideIndex();
+    const slidesPerScroll = this.getProp('slidesPerScroll');
+    const infinite = this.getProp('infinite');
+
+    const prevStep = currentSlideIndex - slidesPerScroll;
+    const nextStep = currentSlideIndex + (slidesPerScroll - 1) + slidesPerScroll;
+
+    let hooped = false;
+    let prevIndex = this.clamp(prevStep);
+    let nextIndex = this.clamp(nextStep);
+
+    if (infinite) {
+      const {
+        value: prevValue,
+        hooped: prevHooped,
+      } = this.hoop(prevStep);
+
+      const {
+        value: nextValue,
+        hooped: nextHooped,
+      } = this.hoop(nextStep);
+
+      prevIndex = prevValue;
+      nextIndex = nextValue;
+      hooped = prevHooped || nextHooped;
+    }
+
+    const lazyLoadedSlides = children.map((_, index) => {
+      if (hooped && ((index >= prevIndex) || (index <= nextIndex))) {
+        return true;
+      }
+
+      if (index >= prevIndex && index <= nextIndex) {
+        return true;
+      }
+
+      // Return previous value, or false
+      return !!this.state.lazyLoadedSlides[index];
+    });
+
+    this.setState({
+      lazyLoadedSlides,
+    });
+  }
+
+  /**
+   * Hoops/Loops number between 0 and last slide index.
+   * @param {number} value to be hooped
+   * @return {object} new value, and was hooped boolean
+   */
+  hoop = value => {
+    const maxValue = this.getChildren().length - 1;
+
+    if (value > maxValue) {
+      return { value: value - maxValue - 1, hooped: true };
+    }
+
+    if (value < 0) {
+      return { value: value + maxValue + 1, hooped: true };
+    }
+
+    return { value, hooped: false };
   };
 
   /**
@@ -256,10 +338,12 @@ class Carousel extends Component {
    * throttled to improve performance
    * @type {Function}
    */
-  onResize = throttle(() => {
+  onResize = throttle(cb => {
     if (!this.node) {
       return;
     }
+
+    const callback = typeof cb === 'function' ? cb : null;
 
     const arrowLeftWidth = this.arrowLeftNode && this.arrowLeftNode.offsetWidth;
     const arrowRightWidth = this.arrowRightNode && this.arrowRightNode.offsetWidth;
@@ -268,7 +352,7 @@ class Carousel extends Component {
     this.setState(() => ({
       carouselWidth: width,
       windowWidth: window.innerWidth,
-    }));
+    }), callback);
   }, config.resizeEventListenerThrottle);
 
   /**
@@ -489,6 +573,7 @@ class Carousel extends Component {
 
   /* ========== rendering ========== */
   renderCarouselItems = () => {
+    const lazyLoad = this.getProp('lazyLoad');
     const isRTL = this.getProp('rtl');
     const transformOffset = this.getTransformOffset();
     const children = this.getChildren();
@@ -542,29 +627,42 @@ class Carousel extends Component {
           onMouseEnter={handleAutoPlayEvent(this.onMouseEnter)}
           onMouseLeave={handleAutoPlayEvent(this.onMouseLeave)}
         >
-          {slides.map((carouselItem, index) => (
-            // eslint-disable-next-line no-undefined
-            [null, undefined].includes(carouselItem) ? null : (
-              <CarouselItem
-                key={index}
-                currentSlideIndex={this.getActiveSlideIndex()}
-                index={index}
-                width={this.getCarouselElementWidth()}
-                offset={index !== slides.length ? this.props.offset : 0}
-                onMouseDown={this.onMouseDown}
-                onTouchStart={this.onTouchStart}
-                clickable={this.getProp('clickToChange')}
-                isDragging={Math.abs(this.state.dragOffset) > this.props.minDraggableOffset}
-                isDraggingEnabled={this.props.draggable || this.props.clickToChange}
-              >
-                {carouselItem}
-              </CarouselItem>
-            )
-          ))}
+          {slides.map((carouselItem, index) => {
+            const realSlideIndex = this.getTargetMod(index);
+
+            return (
+              // eslint-disable-next-line no-undefined
+              [null, undefined].includes(carouselItem) ? null : (
+                <CarouselItem
+                  key={index}
+                  currentSlideIndex={this.getActiveSlideIndex()}
+                  index={index}
+                  width={this.getCarouselElementWidth()}
+                  offset={index !== slides.length ? this.props.offset : 0}
+                  onMouseDown={this.onMouseDown}
+                  onTouchStart={this.onTouchStart}
+                  clickable={this.getProp('clickToChange')}
+                  isDragging={Math.abs(this.state.dragOffset) > this.props.minDraggableOffset}
+                  isDraggingEnabled={this.props.draggable || this.props.clickToChange}
+                >
+                  {
+                    !lazyLoad && carouselItem
+                  }
+                  {
+                    lazyLoad && this.state.lazyLoadedSlides[realSlideIndex]
+                      ? carouselItem
+                      : this.renderLazyLoader()
+                  }
+                </CarouselItem>
+              )
+            );
+          })}
         </ul>
       </div>
     );
   };
+
+  renderLazyLoader = () => this.getProp('lazyLoader') || (<i className="BrainhubCarousel__loader" />);
 
   /**
    * Adds onClick handler to the arrow if possible (if it does not already have one)
@@ -666,7 +764,9 @@ class Carousel extends Component {
     return (
       <div className="BrainhubCarousel__container">
         <div
-          className={classnames('BrainhubCarousel', this.getProp('className'), isRTL ? 'BrainhubCarousel--isRTL' : '')}
+          className={classnames('BrainhubCarousel', this.getProp('className'), {
+            'BrainhubCarousel--isRTL': isRTL,
+          })}
           ref={el => this.node = el}
         >
           <ReactResizeDetector handleWidth onResize={this.onResize}>

--- a/src/styles/Carousel.scss
+++ b/src/styles/Carousel.scss
@@ -1,3 +1,5 @@
+$loaderColor: #7b59ff;
+
 .BrainhubCarousel__container {
   width: 100%;
   overflow: hidden;
@@ -37,4 +39,23 @@
 /* arrows */
 .BrainhubCarousel__arrows {
   cursor: pointer;
+}
+
+/* loader */
+.BrainhubCarousel__loader {
+  width: 50px;
+  height: 50px;
+  border-radius: 100%;
+  border: 4px solid $loaderColor;
+  border-left-color: transparent;
+  animation: loader 1s infinite linear;
+}
+
+@keyframes loader {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }

--- a/test/unit/carousel.test.js
+++ b/test/unit/carousel.test.js
@@ -300,4 +300,57 @@ describe('Carousel', () => {
       expect(wrapper.find('.right')).toHaveLength(0);
     });
   });
+
+  describe('lazy load', () => {
+    it('lazy loads in simple mode', () => {
+      const wrapper = setup({
+        lazyLoad: true,
+      });
+
+      expect(wrapper.find('.BrainhubCarousel__loader')).toHaveLength(1);
+    });
+
+    it('lazy loads previous slide when in infinite mode', () => {
+      const wrapper = mount(
+        <Carousel
+          lazyLoad
+          infinite
+        >
+          <div/>
+          <div/>
+          <div/>
+          <div/>
+        </Carousel>,
+      );
+
+      expect(wrapper.find('.BrainhubCarouselItem').last().children().hasClass('BrainhubCarousel__loader')).toBeFalsy();
+    });
+
+    it('lazy loads more slides if `slidesPerScroll` is set', () => {
+      const wrapper = mount(
+        <Carousel
+          lazyLoad
+          slidesPerScroll={2}
+        >
+          <div/>
+          <div/>
+          <div/>
+          <div/>
+          <div/>
+          <div/>
+        </Carousel>,
+      );
+
+      expect(wrapper.find('.BrainhubCarousel__loader')).toHaveLength(2);
+    });
+
+    it('custom lazy loader element', () => {
+      const wrapper = setup({
+        lazyLoad: true,
+        lazyLoader: <div className="custom-loader" />,
+      });
+
+      expect(wrapper.find('.custom-loader')).toHaveLength(1);
+    });
+  });
 });


### PR DESCRIPTION
- [https://github.com/brainhubeu/react-carousel/issues/389] an issue linked to the PR
I've named prop simply 'lazyLoad', cause basically it lazy loads whole slide, not just one image.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#389: lazy loading of images](https://issuehunt.io/repos/116013398/issues/389)
---
</details>
<!-- /Issuehunt content-->