### PR TITLE
Fixed fast scroll issue

### DIFF
--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -144,15 +144,23 @@ class Carousel extends Component {
   /* ========== tools ========== */
   getCurrentValue = () => this.props.infinite ? this.props.value : this.clamp(this.props.value);
 
-  getNeededAdditionalClones = () =>
-    Math.ceil((this.getCurrentValue() - this.state.infiniteTransitionFrom) / this.getChildren().length);
+  getNeededAdditionalClones = () => {
+    if (Math.abs(this.getCurrentSlideIndex()) > this.getChildren().length) {
+      return Math.ceil((this.getCurrentValue() - this.state.infiniteTransitionFrom) / this.getChildren().length);
+    }
+    return 0;
+  };
 
   getAdditionalClonesLeft = () => {
     const additionalClones = this.getNeededAdditionalClones();
     return additionalClones < 0 ? -additionalClones : 0;
   };
+  getAdditionalClonesRight = () => {
+    const additionalClones = this.getNeededAdditionalClones();
+    return additionalClones > 0 ? additionalClones : 0;
+  };
   getClonesLeft = () => config.numberOfInfiniteClones + this.getAdditionalClonesLeft();
-  getClonesRight = () => config.numberOfInfiniteClones;
+  getClonesRight = () => config.numberOfInfiniteClones + this.getAdditionalClonesRight();
 
   getAdditionalClonesOffset = () =>
     -this.getChildren().length * this.getCarouselElementWidth() * this.getAdditionalClonesLeft();


### PR DESCRIPTION
With this fix the carousel doesn't disappear when scrolling fast many slides right (https://github.com/brainhubeu/react-carousel/pull/461#issuecomment-634126235)

