### PR TITLE
Remove unnecessary id for carousel item

### DIFF
--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -495,8 +495,6 @@ class Carousel extends Component {
     return dragOffset - currentValue * elementWidthWithOffset + additionalOffset - additionalClonesOffset;
   };
 
-  getIdCarouselItem = index => index % this.getChildren().length + 1;
-
   /* ========== rendering ========== */
   renderCarouselItems = () => {
     const isRTL = this.getProp('rtl');
@@ -557,7 +555,6 @@ class Carousel extends Component {
             [null, undefined].includes(carouselItem) ? null : (
               <CarouselItem
                 key={index}
-                id={this.getIdCarouselItem(index)}
                 currentSlideIndex={this.getActiveSlideIndex()}
                 index={index}
                 width={this.getCarouselElementWidth()}

--- a/src/components/CarouselItem.js
+++ b/src/components/CarouselItem.js
@@ -13,7 +13,6 @@ class CarouselItem extends PureComponent {
     width: PropTypes.number,
     offset: PropTypes.number,
     index: PropTypes.number,
-    id: PropTypes.number,
     currentSlideIndex: PropTypes.number,
     isDragging: PropTypes.bool,
     isDraggingEnabled: PropTypes.bool,


### PR DESCRIPTION
As mention by @RobertHebel the id for carousel item is unnecessary.

