### PR TITLE
Add keyboard input support

### DIFF
--- a/docs/api/carousel.md
+++ b/docs/api/carousel.md
@@ -18,6 +18,8 @@
 
 * ```arrowLeft: React element```, ```arrowRight: React element```: React elements to be used instead of default arrows (if you provide these custom arrows, you don't have to use ```arrows``` prop).
 
+* ```left: String | Number```, ```right: String | Number```: The KeyCode or Key for keyboard inputs for changing to the previous or next slide.
+
 * ```addArrowClickHandler: Boolean``` Has to be added for arrowLeft and arrowRight to work.
 
 * ```autoPlay: Number```: Slide change interval in milliseconds.

--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -29,6 +29,8 @@ class Carousel extends Component {
     arrows: PropTypes.bool,
     arrowLeft: PropTypes.element,
     arrowRight: PropTypes.element,
+    left: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    right: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     addArrowClickHandler: PropTypes.bool,
     autoPlay: PropTypes.number,
     stopAutoPlayOnHover: PropTypes.bool,
@@ -67,6 +69,8 @@ class Carousel extends Component {
     offset: 0,
     slidesPerPage: 1,
     slidesPerScroll: 1,
+    left: 37,
+    right: 39,
     animationSpeed: 500,
     draggable: true,
     rtl: false,
@@ -101,6 +105,8 @@ class Carousel extends Component {
       this.node.parentElement.addEventListener('touchmove', this.simulateEvent, { passive: false });
       this.node.parentElement.addEventListener('touchend', this.simulateEvent, true);
     }
+    // focus ref for keyboard input
+    this.trackRef.focus();
 
     this.onResize();
     // setting autoplay interval
@@ -315,6 +321,18 @@ class Carousel extends Component {
       dragStart: changedTouches[0].pageX,
     }));
   };
+
+  /**
+   * Function handling left and right arrow presses.
+   * @param {event} e event
+   */
+  onKeyDown = e => {
+      if (e.keyCode === this.props.left || e.key === this.props.left) {
+        this.prevSlide();
+      } else if (e.keyCode === this.props.right || e.key === this.props.right) {
+        this.nextSlide();
+      }
+  }
 
   /**
    * Function handling end of touch or mouse drag. If drag was long it changes current slide to the nearest one,
@@ -544,6 +562,8 @@ class Carousel extends Component {
           ref={el => this.trackRef = el}
           onMouseEnter={handleAutoPlayEvent(this.onMouseEnter)}
           onMouseLeave={handleAutoPlayEvent(this.onMouseLeave)}
+          onKeyDown={this.onKeyDown}
+          tabIndex="0"
         >
           {slides.map((carouselItem, index) => (
             // eslint-disable-next-line no-undefined


### PR DESCRIPTION
Adding keyboard input support as described in #379 and #535. It allows for users to set either the KeyCode (e.g. 37 for left arrow, 39 for right arrow) or the Key (e.g. "ArrowRight" for right arrow).