### PR TITLE
fix: Setting offset breaks "centered"

### DIFF
--- a/src/components/CarouselItem.js
+++ b/src/components/CarouselItem.js
@@ -77,8 +77,8 @@ class CarouselItem extends PureComponent {
           },
         )}
         style={{
-          paddingRight: `${this.props.offset / 2}px`,
-          paddingLeft: `${this.props.offset / 2}px`,
+          marginLeft: `${this.props.offset / 2}px`,
+          marginRight: `${this.props.offset / 2}px`,
           width: `${this.props.width}px`,
           maxWidth: `${this.props.width}px`,
           minWidth: `${this.props.width}px`,


### PR DESCRIPTION
Closes #394.

After a long discussion in the issue, we decided to change from usage of padding to margin to work around spacing issues with `box-sizing: border-box`, which could be set by css resets or css frameworks by default. 