### PR TITLE
fix: setting offset breaks "centered" plugin #394

### DIFF
--- a/react-carousel/src/components/CarouselSlide.js
+++ b/react-carousel/src/components/CarouselSlide.js
@@ -72,8 +72,8 @@ const CarouselSlide = ({
         ...(itemClassNames || []),
       )}
       style={{
-        paddingRight: `${offset / 2}px`,
-        paddingLeft: `${offset / 2}px`,
+        marginRight: `${offset / 2}px`,
+        marginLeft: `${offset / 2}px`,
         width: `${width}px`,
         maxWidth: `${width}px`,
         minWidth: `${width}px`,


### PR DESCRIPTION
Deployed to https://beghp.github.io/gh-pages-rc-2<br>* change padding to margin to avoid spacing issues with box sizing: border-box<br><br>