### PR TITLE
Fix production builds using webpack

### DIFF
--- a/react-carousel/package.json
+++ b/react-carousel/package.json
@@ -51,8 +51,6 @@
     "node-sass": "^4.13.1",
     "postcss-loader": "^3.0.0",
     "prop-types": "^15.7.2",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1",
     "react-resize-detector": "^5.0.6",
     "react-test-renderer": "^16.13.1",
     "recoil": "^0.0.10",

--- a/react-carousel/package.json
+++ b/react-carousel/package.json
@@ -53,7 +53,7 @@
     "prop-types": "^15.7.2",
     "react-resize-detector": "^5.0.6",
     "react-test-renderer": "^16.13.1",
-    "recoil": "^0.0.10",
+    "recoil": "^0.0.11",
     "resize-observer-polyfill": "^1.5.1",
     "rimraf": "3.0.2",
     "sass-loader": "^8.0.2",

--- a/react-carousel/webpack.config.prod.js
+++ b/react-carousel/webpack.config.prod.js
@@ -6,6 +6,7 @@ const autoprefixer = require('autoprefixer');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 
 module.exports = {
+  mode: 'production',
   externals: [
     {
       'react-dom': {
@@ -48,7 +49,9 @@ module.exports = {
     new ExtractTextPlugin('style.css'),
     new webpack.DefinePlugin({
       // This fixes https://github.com/brainhubeu/react-carousel/issues/115
-      'process.env.NODE_ENV': process.env.NODE_ENV,
+      'process.env': {
+        NODE_ENV: JSON.stringify('production')
+      }
     }),
   ],
   module: {


### PR DESCRIPTION
It appears that `react` and `react-dom` were specified in both the peerDependencies and normal dependencies. There are some issues when packaging react apps with webpack when multiple copies of React are present in the same (packaged) app (see also: https://reactjs.org/warnings/invalid-hook-call-warning.html).

The webpack config is still not ideal, as it does not set the production environment but just happens to default to it. I have also found some weird behavior with the manual set on [L51](https://github.com/brainhubeu/react-carousel/blob/master/react-carousel/webpack.config.prod.js#L51) and Recoil, but this is not the root cause and only causes a "degrade" to development mode in Recoil. This may be better suited for a different issue however.

For now the builds seem to work locally, let me know if more information is needed.

- Fixes https://github.com/brainhubeu/react-carousel/issues/633
- Fixes https://github.com/brainhubeu/react-carousel/issues/634
