### PR TITLE
Fix CSS for arrows plug-in and controlled component

### DIFF
--- a/react-carousel/src/components/CarouselWrapper.js
+++ b/react-carousel/src/components/CarouselWrapper.js
@@ -49,7 +49,7 @@ const CarouselWrapper = (props) => {
       key={carouselProps?.plugins?.length || 0}
       transformOffset={transformOffset}
       nearestSlideIndex={nearestSlideIndex}
-      value={value}
+      value={isControlled ? customValue : value}
       onChange={isControlled ? onChange : changeSlide}
       {...carouselProps}
     />

--- a/react-carousel/src/styles/Carousel.scss
+++ b/react-carousel/src/styles/Carousel.scss
@@ -23,6 +23,7 @@ $loaderColor: #7b59ff;
   .BrainhubCarousel__trackContainer {
     width: 100%;
     overflow: hidden;
+    flex-shrink: 1;
     .BrainhubCarousel__track {
       display: flex;
       overflow: hidden;


### PR DESCRIPTION
Hello,

I submit this PR for my own work.

When you use the arrows, if flex-shrink isn't set to 1, the right arrow is outside the screen.
You can't use controlled components because the value was always﻿the inside value.

Please merge this PR and update it on NPM

Thanks
MrNossiom
