### PR TITLE
Feature/add classNames for relative position to active slide

### DIFF
--- a/react-carousel/src/components/CarouselSlide.js
+++ b/react-carousel/src/components/CarouselSlide.js
@@ -66,8 +66,11 @@ const CarouselSlide = ({
     <li
       className={classname(
         'BrainhubCarouselItem',
+        `BrainhubCarouselItem--relindex-${Math.abs(index - currentSlideIndex)}`,
         {
           'BrainhubCarouselItem--active': index === currentSlideIndex,
+          'BrainhubCarouselItem--before': index < currentSlideIndex,
+          'BrainhubCarouselItem--after': index > currentSlideIndex,
         },
         ...(itemClassNames || []),
       )}


### PR DESCRIPTION
Implementing the feature described in https://github.com/brainhubeu/react-carousel/issues/670

Adding 
- If slide is before the active it has the className `BrainhubCarouselItem--before`
- If slide is after the active it has the className `BrainhubCarouselItem--after`
- All slides has the relative index as a className `BrainhubCarouselItem--relindex-X` (where X is the absolute difference between its index and the selected index)
