### PR TITLE
style: add low opacity to disabled arrows

### DIFF
--- a/react-carousel/src/styles/Arrows.scss
+++ b/react-carousel/src/styles/Arrows.scss
@@ -54,7 +54,7 @@ $arrowWeight: 3px;
         }
     }
   }
-  
+
   &:disabled {
     background-color: $disabledButtonColor;
   }
@@ -112,5 +112,6 @@ $arrowWeight: 3px;
 
 .BrainhubCarousel__arrow--disable {
     pointer-events: none;
+    opacity: 0.5;
 }
 


### PR DESCRIPTION
I think it's a good idea to add a lower opacity to disabled arrows as default style.
