### PR TITLE
chore: add react 17 to peerDependencies

### DIFF
--- a/react-carousel/package.json
+++ b/react-carousel/package.json
@@ -63,8 +63,8 @@
     "webpack": "^4.42.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react": "^16.8.0 || ^17.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0"
   },
   "keywords": [
     "react",


### PR DESCRIPTION
- [ https://github.com/brainhubeu/react-carousel/issues/734] an issue linked to the PR

Please, consider this update to peerDependencies so codebases using React 17 can still enjoy your cool library :D 