### PR TITLE
fix: arrowRight custom arrow given wrong className

### DIFF
--- a/react-carousel/src/plugins/arrows.js
+++ b/react-carousel/src/plugins/arrows.js
@@ -106,7 +106,7 @@ const arrows = ({ carouselProps, options = {} }) => ({
         return renderArrowWithAddedHandler(
           options.arrowRight,
           nextSlide,
-          'arrowLeft',
+          'arrowRight',
           options.addArrowClickHandler,
           '@brainhubeu/react-carousel/custom-arrow-right',
         );
@@ -117,7 +117,7 @@ const arrows = ({ carouselProps, options = {} }) => ({
       return renderArrowWithAddedHandler(
         arrow,
         nextSlide,
-        'arrowLeft',
+        'arrowRight',
         options.addArrowClickHandler,
         '@brainhubeu/react-carousel/custom-arrow-right',
         disabled,

--- a/react-carousel/test/plugins/arrows.test.js
+++ b/react-carousel/test/plugins/arrows.test.js
@@ -89,9 +89,12 @@ describe('arrows', () => {
         },
       ],
     });
-
+    expect(wrapper.find('.BrainhubCarousel__custom-arrowLeft')).toHaveLength(1);
     expect(wrapper.find('.left-disabled')).toHaveLength(1);
 
+    expect(wrapper.find('.BrainhubCarousel__custom-arrowRight')).toHaveLength(
+      1,
+    );
     wrapper.find('.right').simulate('click');
 
     expect(wrapper.find('.left-disabled')).toHaveLength(0);


### PR DESCRIPTION
Was formerly given a className ending in `arrowLeft`, not the expected `arrowRight`



- [ ] an issue linked to the PR
